### PR TITLE
Maximum number of contributors in a single request

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -10,7 +10,7 @@
             dataType: 'jsonp',
             timeout: 3000,
             type: 'GET',
-            url: 'https://api.github.com/repos/codeguy/php-the-right-way/contributors'
+            url: 'https://api.github.com/repos/codeguy/php-the-right-way/contributors?per_page=100'
         }).done(function (data) {
             if ( data.data && data.data.length ) {
                 var $ul = $('<ul></ul>'), dataLength = data.data.length;


### PR DESCRIPTION
The Github api limits results to 30 per page by default.
The maximum for a single result of contributors is 100.
