### PR TITLE
잘못된 링크들을 수정

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -60,7 +60,7 @@
                 {% endfor %}
                     </ul>
                 </li>
-                <li><a href="/#credits">Credits</a></li>
+                <li><a href="#credits">Credits</a></li>
             </ul>
         </nav>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
     </head>
     <body>
         <header class="site-header">
-            <h1><a href="/">PHP <em>The Right Way</em></a></h1>
+            <h1><a href="/php-the-right-way/">PHP <em>The Right Way</em></a></h1>
             <div class="build-date">Last Updated: {{ site.time }}</div>
             <div class="share">
                 <a class="btn-share" href="https://twitter.com/intent/tweet?text=PHP+The+Right+Way&amp;url=http%3A%2F%2Fmodernpug.github.io%2Fphp-the-right-way&amp;hashtags=PHP" target="_blank">트위터로 공유</a>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -22,7 +22,7 @@
     </head>
     <body>
         <header class="site-header">
-            <h1><a href="/">PHP <em>The Right Way</em></a></h1>
+            <h1><a href="/php-the-right-way/">PHP <em>The Right Way</em></a></h1>
             <div class="build-date">Last Updated: {{ site.time }}</div>
             <div class="share">
                 <a class="btn-share" href="https://twitter.com/intent/tweet?text=PHP+The+Right+Way&amp;url=http%3A%2F%2Fmodernpug.github.io%2Fphp-the-right-way&amp;hashtags=PHP" target="_blank">트위터로 공유</a>


### PR DESCRIPTION
"PHP the write way" 라고 써 있는 메인 헤더를 클릭하면 "http://modernpug.github.io/" 로 이동하면서 github 404 페이지가 나타나는 문제를 발견하여 수정해보았습니다.

_layouts/default.html과 _layouts/page.html 에서 a tag 링크 주소를 "/" 에서 "/php-the-right-way/" 로 수정했습니다.

좋은 해결책인지는 약간 의심이 됩니다만 딱히 다른 방법은 생각나지 않아 이렇게 PR을 보내봅니다.
